### PR TITLE
Handle missing book IDs

### DIFF
--- a/src-tauri/src/commands/book.rs
+++ b/src-tauri/src/commands/book.rs
@@ -101,9 +101,11 @@ pub fn update_book(book: UpdateBook, db: State<DbConnection>) -> Result<Book, St
 #[tauri::command]
 pub fn delete_book(id: i64, db: State<DbConnection>) -> Result<(), String> {
     let conn = db.0.lock().unwrap();
-    crate::db::delete_book(&conn, id)
-        .map(|_| ()) // 成功したら usize を () に変換
-        .map_err(|e| e.to_string())
+    match crate::db::delete_book(&conn, id) {
+        Ok(affected) if affected > 0 => Ok(()),
+        Ok(_) => Err(format!("Book with id {} not found", id)),
+        Err(e) => Err(e.to_string()),
+    }
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- return an error when attempting to delete a book that does not exist

## Testing
- `cargo test` *(fails: The system library `gio-2.0` required by crate `gio-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f64f897c8323b4cd6944e059d12f