### PR TITLE
feat: add amazon api option

### DIFF
--- a/src-tauri/src/commands/amazon_api.rs
+++ b/src-tauri/src/commands/amazon_api.rs
@@ -1,0 +1,18 @@
+use crate::models::BookInfoFromApi;
+
+/// Fetch book information from Amazon Product Advertising API.
+///
+/// This is currently a placeholder implementation that simply returns an
+/// error. In a real-world scenario, this function would sign a request using
+/// the access key, secret key and associate tag, call Amazon's API and parse
+/// the response.
+#[tauri::command]
+pub async fn fetch_book_info_from_amazon(
+    isbn: String,
+    access_key: String,
+    secret_key: String,
+    associate_tag: String,
+) -> Result<BookInfoFromApi, String> {
+    let _ = (isbn, access_key, secret_key, associate_tag); // suppress unused warnings
+    Err("Amazon API integration is not implemented".to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,7 +1,9 @@
 pub mod book;
 pub mod genre;
 pub mod ndl_api;
+pub mod amazon_api;
 
 pub use book::*;
 pub use genre::*;
 pub use ndl_api::*;
+pub use amazon_api::*;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
             commands::update_book,
             commands::add_genre,
             commands::fetch_book_info_from_ndl,
+            commands::fetch_book_info_from_amazon,
             commands::delete_book,
             commands::get_book_count_by_genre,
             commands::delete_genre,

--- a/src/components/AddBookForm.vue
+++ b/src/components/AddBookForm.vue
@@ -140,7 +140,7 @@ function onIsbnEnter(event: KeyboardEvent) {
   searchByIsbn();
 }
 
-// NDL APIを呼び出すように修正
+// 選択されたAPIから書籍情報を取得
 async function searchByIsbn() {
   errorMsg.value = '';
   if (!isbnInput.value.trim()) {
@@ -149,12 +149,24 @@ async function searchByIsbn() {
   }
   searching.value = true;
   try {
-    const result = await invoke<BookInfoFromApi>('fetch_book_info_from_ndl', {
-      isbn: isbnInput.value.trim(),
-    });
-    // 取得した情報を一時保持
+    const apiChoice = localStorage.getItem('bookInfoApi') || 'ndl';
+    let result: BookInfoFromApi;
+    if (apiChoice === 'amazon') {
+      const accessKey = localStorage.getItem('amazonAccessKey') || '';
+      const secretKey = localStorage.getItem('amazonSecretKey') || '';
+      const associateTag = localStorage.getItem('amazonAssociateTag') || '';
+      result = await invoke<BookInfoFromApi>('fetch_book_info_from_amazon', {
+        isbn: isbnInput.value.trim(),
+        accessKey,
+        secretKey,
+        associateTag,
+      });
+    } else {
+      result = await invoke<BookInfoFromApi>('fetch_book_info_from_ndl', {
+        isbn: isbnInput.value.trim(),
+      });
+    }
     tempBookInfo.value = result;
-    // JANコード入力ポップアップを表示
     showJanPopup.value = true;
     janCode.value = '';
     janErrorMsg.value = '';

--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { ref } from 'vue';
 
 defineProps<{
   show: boolean;

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -1,4 +1,3 @@
-```vue
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 
@@ -6,23 +5,35 @@ const emit = defineEmits<{
   (e: 'close'): void
 }>();
 
-const apiKey = ref('');
+const apiChoice = ref<'ndl' | 'amazon'>('ndl');
+const amazonAccessKey = ref('');
+const amazonSecretKey = ref('');
+const amazonAssociateTag = ref('');
 const saving = ref(false);
 const errorMsg = ref('');
 
-const STORAGE_KEY = 'googleBooksApiKey';
+const STORAGE_API = 'bookInfoApi';
+const STORAGE_AMAZON_ACCESS = 'amazonAccessKey';
+const STORAGE_AMAZON_SECRET = 'amazonSecretKey';
+const STORAGE_AMAZON_ASSOCIATE = 'amazonAssociateTag';
 
 onMounted(() => {
-  apiKey.value = localStorage.getItem(STORAGE_KEY) || '';
+  apiChoice.value = (localStorage.getItem(STORAGE_API) as 'ndl' | 'amazon') || 'ndl';
+  amazonAccessKey.value = localStorage.getItem(STORAGE_AMAZON_ACCESS) || '';
+  amazonSecretKey.value = localStorage.getItem(STORAGE_AMAZON_SECRET) || '';
+  amazonAssociateTag.value = localStorage.getItem(STORAGE_AMAZON_ASSOCIATE) || '';
 });
 
 function save() {
   errorMsg.value = '';
   saving.value = true;
   try {
-    // 簡易バリデーション（任意）
-    // 空文字は許容（APIキー未設定のまま使う場合があるため）
-    localStorage.setItem(STORAGE_KEY, apiKey.value.trim());
+    localStorage.setItem(STORAGE_API, apiChoice.value);
+    if (apiChoice.value === 'amazon') {
+      localStorage.setItem(STORAGE_AMAZON_ACCESS, amazonAccessKey.value.trim());
+      localStorage.setItem(STORAGE_AMAZON_SECRET, amazonSecretKey.value.trim());
+      localStorage.setItem(STORAGE_AMAZON_ASSOCIATE, amazonAssociateTag.value.trim());
+    }
     emit('close');
   } catch (e) {
     console.error(e);
@@ -46,9 +57,22 @@ function cancel() {
 
     <div class="settings-body" style="padding:12px;">
       <div class="row" style="margin-bottom:10px;">
-        <label style="display:block;font-weight:600;margin-bottom:6px;">Google Books API キー</label>
-        <input v-model="apiKey" placeholder="API キーを入力（未入力可）" style="width:100%;padding:6px;border:1px solid #bbb;border-radius:4px;" />
-        <p style="margin:8px 0 0;font-size:12px;color:#666;">将来的に自動ISBN検索で使用します。APIキーなしでも手動入力は可能です。</p>
+        <label style="display:block;font-weight:600;margin-bottom:6px;">使用するAPI</label>
+        <select v-model="apiChoice" style="width:100%;padding:6px;border:1px solid #bbb;border-radius:4px;">
+          <option value="ndl">NDL</option>
+          <option value="amazon">Amazon</option>
+        </select>
+      </div>
+
+      <div v-if="apiChoice === 'amazon'" style="margin-bottom:10px;">
+        <label style="display:block;font-weight:600;margin-bottom:6px;">Amazon アクセスキーID</label>
+        <input v-model="amazonAccessKey" style="width:100%;padding:6px;border:1px solid #bbb;border-radius:4px;" />
+
+        <label style="display:block;font-weight:600;margin:10px 0 6px;">Amazon シークレットキー</label>
+        <input v-model="amazonSecretKey" style="width:100%;padding:6px;border:1px solid #bbb;border-radius:4px;" />
+
+        <label style="display:block;font-weight:600;margin:10px 0 6px;">Amazon アソシエイトID</label>
+        <input v-model="amazonAssociateTag" style="width:100%;padding:6px;border:1px solid #bbb;border-radius:4px;" />
       </div>
 
       <div class="actions" style="display:flex;gap:12px;align-items:center;">
@@ -92,4 +116,3 @@ function cancel() {
   font-size: 13px;
 }
 </style>
-```


### PR DESCRIPTION
## Summary
- add settings to choose NDL or Amazon API and input Amazon credentials
- call appropriate API in AddBookForm
- stub Tauri command for Amazon book lookup

## Testing
- `pnpm run build`
- `cargo check` *(fails: The system library `gio-2.0` required by crate `gio-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a75c66cda48323bbe86049cd0aa912