### PR TITLE
Add Rakuten Books API auto-fill option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bibly
 
-簡単な書籍管理デスクトップアプリ（Tauri + Vue）。ISBNから国立国会図書館（NDL）APIやGoogle Books APIを使って自動入力する機能を備えています。設定画面で使用するAPIを選択できます。
+簡単な書籍管理デスクトップアプリ（Tauri + Vue）。ISBNから国立国会図書館（NDL）APIやGoogle Books API、楽天ブックスAPIを使って自動入力する機能を備えています。設定画面で使用するAPIを選択できます。
 
 ## 主要ファイル
 - フロントエンド（Vue 3）
@@ -12,6 +12,7 @@
   - アプリ起動: [src-tauri/src/main.rs](src-tauri/src/main.rs)
   - NDL検索コマンド: [`commands::fetch_book_info_from_ndl`](src-tauri/src/commands/mod.rs) （Tauriコマンド）
   - Google Books検索コマンド: [`commands::fetch_book_info_from_google_books`](src-tauri/src/commands/mod.rs)
+  - 楽天ブックス検索コマンド: [`commands::fetch_book_info_from_rakuten`](src-tauri/src/commands/mod.rs)
 
 ## 必要環境
 - Node.js（推奨: LTS）
@@ -43,7 +44,7 @@
 
 ## ISBN 自動入力について
 - UI: [src/components/AddBookForm.vue](src/components/AddBookForm.vue) の「自動入力 (ISBN)」タブから利用可能。
-- 実際の検索は Tauri コマンド [`commands::fetch_book_info_from_ndl`](src-tauri/src/commands/mod.rs) または [`commands::fetch_book_info_from_google_books`](src-tauri/src/commands/mod.rs) に委譲されます。設定で選択したAPIに応じてバックエンドで API を呼び出し、タイトル・著者・出版社を返します。
+- 実際の検索は Tauri コマンド [`commands::fetch_book_info_from_ndl`](src-tauri/src/commands/mod.rs) または [`commands::fetch_book_info_from_google_books`](src-tauri/src/commands/mod.rs)、[`commands::fetch_book_info_from_rakuten`](src-tauri/src/commands/mod.rs) に委譲されます。設定で選択したAPIに応じてバックエンドで API を呼び出し、タイトル・著者・出版社を返します。
 - バックエンドの依存は [src-tauri/Cargo.toml](src-tauri/Cargo.toml) を確認してください（例: reqwest, quick-xml）。
 
 ## 注意点 / トラブルシューティング

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,8 +2,10 @@ pub mod book;
 pub mod genre;
 pub mod google_books_api;
 pub mod ndl_api;
+pub mod rakuten_books_api;
 
 pub use book::*;
 pub use genre::*;
 pub use google_books_api::*;
 pub use ndl_api::*;
+pub use rakuten_books_api::*;

--- a/src-tauri/src/commands/rakuten_books_api.rs
+++ b/src-tauri/src/commands/rakuten_books_api.rs
@@ -1,0 +1,51 @@
+use crate::models::BookInfoFromApi;
+use serde_json::Value;
+
+#[tauri::command]
+pub async fn fetch_book_info_from_rakuten(
+    isbn: String,
+    application_id: String,
+) -> Result<BookInfoFromApi, String> {
+    let url = format!(
+        "https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?applicationId={}&isbn={}",
+        application_id, isbn
+    );
+
+    let resp = reqwest::get(&url).await.map_err(|e| e.to_string())?;
+    let json: Value = resp.json().await.map_err(|e| e.to_string())?;
+
+    if let Some(items) = json["Items"].as_array() {
+        if let Some(item) = items
+            .first()
+            .and_then(|i| i.get("Item"))
+        {
+            let title = item
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let author = item
+                .get("author")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let publisher = item
+                .get("publisherName")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if !title.is_empty() && !author.is_empty() && !publisher.is_empty() {
+                return Ok(BookInfoFromApi {
+                    title,
+                    author,
+                    publisher,
+                });
+            } else {
+                return Err("書籍情報が不足しています".to_string());
+            }
+        }
+    }
+
+    Err("書籍情報が見つかりませんでした".to_string())
+}
+

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
             commands::add_genre,
             commands::fetch_book_info_from_ndl,
             commands::fetch_book_info_from_google_books,
+            commands::fetch_book_info_from_rakuten,
             commands::delete_book,
             commands::get_book_count_by_genre,
             commands::delete_genre,

--- a/src/components/AddBookForm.vue
+++ b/src/components/AddBookForm.vue
@@ -36,7 +36,8 @@ const janErrorMsg = ref('');
 const tempBookInfo = ref<BookInfoFromApi | null>(null); // NDLからの情報を一時保持
 const janInputEl = ref<HTMLInputElement | null>(null); // JANコード入力欄のDOM参照
 
-const API_KEY_STORAGE = 'googleBooksApiKey';
+const GOOGLE_API_KEY_STORAGE = 'googleBooksApiKey';
+const RAKUTEN_APP_ID_STORAGE = 'rakutenApplicationId';
 const PROVIDER_STORAGE = 'bookInfoApiProvider';
 
 // JANコードポップアップが表示されたら入力欄にフォーカスを当てる
@@ -155,10 +156,16 @@ async function searchByIsbn() {
     const provider = localStorage.getItem(PROVIDER_STORAGE) || 'ndl';
     let result: BookInfoFromApi;
     if (provider === 'google') {
-      const apiKey = localStorage.getItem(API_KEY_STORAGE) || '';
+      const apiKey = localStorage.getItem(GOOGLE_API_KEY_STORAGE) || '';
       result = await invoke<BookInfoFromApi>('fetch_book_info_from_google_books', {
         isbn: isbnInput.value.trim(),
         apiKey,
+      });
+    } else if (provider === 'rakuten') {
+      const applicationId = localStorage.getItem(RAKUTEN_APP_ID_STORAGE) || '';
+      result = await invoke<BookInfoFromApi>('fetch_book_info_from_rakuten', {
+        isbn: isbnInput.value.trim(),
+        applicationId,
       });
     } else {
       result = await invoke<BookInfoFromApi>('fetch_book_info_from_ndl', {

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -5,17 +5,21 @@ const emit = defineEmits<{
   (e: 'close'): void
 }>();
 
-const apiKey = ref('');
-const apiProvider = ref<'ndl' | 'google'>('ndl');
+const googleApiKey = ref('');
+const rakutenAppId = ref('');
+const apiProvider = ref<'ndl' | 'google' | 'rakuten'>('ndl');
 const saving = ref(false);
 const errorMsg = ref('');
 
-const API_KEY_STORAGE = 'googleBooksApiKey';
+const GOOGLE_API_KEY_STORAGE = 'googleBooksApiKey';
+const RAKUTEN_APP_ID_STORAGE = 'rakutenApplicationId';
 const PROVIDER_STORAGE = 'bookInfoApiProvider';
 
 onMounted(() => {
-  apiKey.value = localStorage.getItem(API_KEY_STORAGE) || '';
-  apiProvider.value = (localStorage.getItem(PROVIDER_STORAGE) as 'ndl' | 'google') || 'ndl';
+  googleApiKey.value = localStorage.getItem(GOOGLE_API_KEY_STORAGE) || '';
+  rakutenAppId.value = localStorage.getItem(RAKUTEN_APP_ID_STORAGE) || '';
+  apiProvider.value =
+    (localStorage.getItem(PROVIDER_STORAGE) as 'ndl' | 'google' | 'rakuten') || 'ndl';
 });
 
 function save() {
@@ -23,8 +27,8 @@ function save() {
   saving.value = true;
   try {
     localStorage.setItem(PROVIDER_STORAGE, apiProvider.value);
-    // 空文字は許容（APIキー未設定のまま使う場合があるため）
-    localStorage.setItem(API_KEY_STORAGE, apiKey.value.trim());
+    localStorage.setItem(GOOGLE_API_KEY_STORAGE, googleApiKey.value.trim());
+    localStorage.setItem(RAKUTEN_APP_ID_STORAGE, rakutenAppId.value.trim());
     emit('close');
   } catch (e) {
     console.error(e);
@@ -52,13 +56,19 @@ function cancel() {
         <select v-model="apiProvider" style="width:100%;padding:6px;border:1px solid #bbb;border-radius:4px;">
           <option value="ndl">NDL</option>
           <option value="google">Google Books</option>
+          <option value="rakuten">Rakuten Books</option>
         </select>
       </div>
 
       <div class="row" style="margin-bottom:10px;" v-if="apiProvider === 'google'">
         <label style="display:block;font-weight:600;margin-bottom:6px;">Google Books API キー</label>
-        <input v-model="apiKey" placeholder="API キーを入力（未入力可）" style="width:100%;padding:6px;border:1px solid #bbb;border-radius:4px;" />
+        <input v-model="googleApiKey" placeholder="API キーを入力（未入力可）" style="width:100%;padding:6px;border:1px solid #bbb;border-radius:4px;" />
         <p style="margin:8px 0 0;font-size:12px;color:#666;">将来的に自動ISBN検索で使用します。APIキーなしでも手動入力は可能です。</p>
+      </div>
+
+      <div class="row" style="margin-bottom:10px;" v-if="apiProvider === 'rakuten'">
+        <label style="display:block;font-weight:600;margin-bottom:6px;">Rakuten Books アプリケーションID</label>
+        <input v-model="rakutenAppId" placeholder="アプリケーションIDを入力" style="width:100%;padding:6px;border:1px solid #bbb;border-radius:4px;" />
       </div>
 
       <div class="actions" style="display:flex;gap:12px;align-items:center;">


### PR DESCRIPTION
## Summary
- allow choosing Rakuten Books API and storing its application ID in settings
- support fetching book info from Rakuten Books API on the backend
- document Rakuten Books API usage

## Testing
- `pnpm build` *(fails: ConfirmModal.vue TS6133: 'ref' is declared but its value is never read)*
- `cargo check` *(fails: system library `gio-2.0` required by crate `gio-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a87dadee688323bcb583a78941d5af